### PR TITLE
Fix push with httplib

### DIFF
--- a/situp.py
+++ b/situp.py
@@ -270,11 +270,13 @@ class Push(Command):
                         conn = httplib.HTTPSConnection(server.strip('https://'))
                     else:
                         conn = httplib.HTTPConnection(server.strip('http://'))
-                    conn.putheader("User-Agent", "situp-%s" % __version__)
                     if auth:
-                        conn.request(method, url, headers={"Authorization": "Basic %s" % auth})
+                        conn.putrequest(method, url,
+                                headers={"Authorization": "Basic %s" % auth})
                     else:
-                        conn.request(method, url)
+                        conn.putrequest(method, url)
+                    conn.putheader("User-Agent", "situp-%s" % __version__)
+                    conn.endheaders()
                     response = conn.getresponse()
                     conn.close()
                     return response
@@ -301,7 +303,6 @@ class Push(Command):
             except Exception, e:
                 self.logger.error("upload to %s failed" % server)
                 self.logger.info(e)
-                self.logger.debug(data)
 
 
     def _walk_design(self, name, design, options):


### PR DESCRIPTION
Uses putrequest rather than request and moves the putheader call until
after the putrequest.

Also removes a bad log in the except clause.
