### PR TITLE
Fix AddServer

### DIFF
--- a/situp.py
+++ b/situp.py
@@ -199,8 +199,8 @@ class AddServer(Command):
                 dest="name",
                 help="The simple name server to add [required]")
 
-    def process_args(self, args=None, options=None):
-        options, args = Command.process_args(self, args, options)
+    def _process_args(self, args=None, options=None):
+        options, args = Command._process_args(self)
         msg = 'Username for server, press enter for no user/password auth:'
         username = raw_input(msg)
         if username:


### PR DESCRIPTION
AddServer wasn't asking for usernames or encoding auth like it should. Turns out AddServer.process_args wasn't getting called.

Renamed process_args to _process_args and fixed call to
Command._process_args.
